### PR TITLE
Fix commit func to work with more than one flag

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -270,7 +270,7 @@ Repository.prototype.commit = function() {
   var args = Array.prototype.slice.apply(arguments);
   var message = args[0];
   var done = args.slice(-1).pop() || function() { };
-  var flags = Array.isArray(args[1]) ? args[1].push('-m') : ['-m'];
+  var flags = Array.isArray(args[1]) ? args[1].concat('-m') : ['-m'];
   var cmd = new Command(this, 'commit', flags, '"' + message + '"');
 
   cmd.exec(function(err, stdout, stderr) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
   },
   "contributors": [
     {
+      "name": "Anna Gray",
+      "url": "https://github.com/annagray"
+     },
+    {
       "name": "Christopher Meyering",
       "url": "https://github.com/MeySolution"
     },


### PR DESCRIPTION
Using .concat instead of .push when appending '-m' flag onto the end of the flags array (concat returns the array rather than the length)