### PR TITLE
Pass optional options to Repository constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,19 @@ $ npm test
 
 ```js
 var git    = require('gitty');
+
+// identifying the repo and using defaults
 var myRepo = git('/path/to/repo');
+
+// explicitly passing the path to the git client
+var myRepo2 = git('/path/to/repo2', '/not-in-path/bin/git');
+
+// specifying an options object (note all properties are optional)
+var myRepo3 = git('/path/to/repo3', {
+  gitpath: '/not-in-path/bin/git',                          // optional
+  largeOperations: ['log', 'ls-files', 'status', 'commit'], // optional
+  largeOperationsMaxBuffer: 1024 * 6000                     // optional
+});
 ```
 
 Now you can call this instance of `Repository`'s methods. For example, to

--- a/lib/command.js
+++ b/lib/command.js
@@ -3,11 +3,12 @@
 var childproc = require('child_process');
 var exec = childproc.exec;
 var execSync = childproc.execSync;
+var utils = require('./utils');
 
 /**
 * Setup function for running git commands on the command line
 * @constructor
-* @param {Repository} repo
+* @param {Repository|string} repo or a string identifying the repo
 * @param {string} operation
 * @param {array}  flags
 * @param {string} options
@@ -15,22 +16,25 @@ var execSync = childproc.execSync;
 var Command = function(repo, operation, flags, options) {
   flags = flags || [];
   options = options || '';
-  var largeOperations = ['log', 'ls-files'];
 
-  if (typeof repo === 'string') {
+  // Some operations on very large repos or long-lived repos will
+  // require more stdout buffer. The default (200K) seems sufficient
+  // for most operations except for 'log'.
+  this.execBuffer = 1024 * 200;
+
+  if (utils.isObject(repo)) {
+    this.repo = repo;
+    var largeOperations = repo.largeOperations || ['log', 'ls-files'];
+    if (largeOperations.indexOf(operation) > -1) {
+      this.execBuffer = repo.largeOperationsMaxBuffer || 1024 * 5000;
+    }
+  } else if (utils.isString(repo)) {
     this.repo = { path: repo, gitpath: '' };
   } else {
-    this.repo = repo || { path: '/', gitpath: '' };
+    this.repo = { path: '/', gitpath: '' };
   }
   this.command = (this.repo.gitpath ? this.repo.gitpath + ' ' : 'git ') +
     operation + ' ' + flags.join(' ') + ' ' + options;
-  // The log on long lived active repos will require more stdout buffer.
-  // The default (200K) seems sufficient for all other operations.
-  this.execBuffer = 1024 * 200;
-
-  if (largeOperations.indexOf(operation) > -1) {
-    this.execBuffer = 1024 * 5000;
-  }
 };
 
 /**

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
+var utils = require('./utils');
 var Command = require('./command');
 var parse = require('./parser');
 var events = require('events');
@@ -14,24 +15,49 @@ if (require('os').platform() === 'win32') {
 }
 
 /**
-* Represents a Git repository
+* Represents a Git repository.
+* Requires 'repo' string identifying the local repository directory.
+* Accepts optional 'gitpathOrOpts' that may be a string identifying the
+* path to the native git client or an object containing an optional
+* 'gitpath' property, an optional 'largeOperations' property, and an
+* optional 'largeOperationsMaxBuffer'.
+* {
+*   gitpath: a string representing the path to the git client
+*   largeOperations: array of strings identifying large operations
+*   largeOperationsMaxBuffer: number, default is 1024 * 5000
+* }
 * @constructor
 * @param {string} repo
-* @param {string} gitpath
+* @param {string|object} gitpathOrOpts a 'gitpath' string or opts object
 */
-var Repository = function(repo, gitpath) {
+var Repository = function(repo, gitpathOrOpts) {
   if (!(this instanceof Repository)) {
-    return new Repository(repo, gitpath);
+    return new Repository(repo, gitpathOrOpts);
   }
 
   var self = this;
 
   events.EventEmitter.call(this);
 
-  self.gitpath = gitpath ? path.normalize(gitpath) : '';
+  if (utils.isString(gitpathOrOpts)) { // interpret 'opts' string as gitpath
+    self.gitpath = path.normalize(gitpathOrOpts);
+  }
+  if (utils.isObject(gitpathOrOpts)) {
+    var opts = gitpathOrOpts;
+    if (opts.gitpath) {
+      self.gitpath = path.normalize(opts.gitpath);
+    }
+    self.largeOperations = opts.largeOperations;
+    self.largeOperationsMaxBuffer = opts.largeOperationsMaxBuffer;
+  }
   self.path = path.normalize(repo);
   self._ready = false;
   self.name = path.basename(self.path);
+
+  // apply defaults
+  self.gitpath = self.gitpath || '';
+  self.largeOperations = self.largeOperations || ['log', 'ls-files'];
+  self.largeOperationsMaxBuffer = self.largeOperationsMaxBuffer || 1024 * 5000;
 
   fs.exists(self.path + '/.git', function(exists) {
     self.initialized = exists;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function isObject(thing) {
+  return thing !== null && typeof thing === 'object'
+}
+
+function isString(thing) {
+  return typeof thing === 'string' || thing instanceof String;
+}
+
+module.exports = {
+  isObject: isObject,
+  isString: isString
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitty",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A Node.js wrapper for the Git CLI",
   "main": "index",
   "dependencies": {},

--- a/test/command.unit.js
+++ b/test/command.unit.js
@@ -31,6 +31,20 @@ describe('Command', function() {
       cmd.repo.gitpath.should.equal('/path/to/git');
     });
 
+    it('should set execBuffer based upon the repo object', function() {
+      var largeOps = ['log', 'ls-files', 'status', 'commit'];
+      var defaultBuf = 1024 * 200;
+      var maxBuf = 1024 * 6000;
+      var repo = {
+        largeOperations: largeOps,
+        largeOperationsMaxBuffer: maxBuf
+      };
+      var fetchCmd = new Command(repo, 'fetch');
+      fetchCmd.execBuffer.should.equal(defaultBuf);
+      var commitCmd = new Command(repo, 'status');
+      commitCmd.execBuffer.should.equal(maxBuf);
+    });
+
   });
 
   describe('.exec()', function() {

--- a/test/repository.unit.js
+++ b/test/repository.unit.js
@@ -53,6 +53,70 @@ describe('Repository', function() {
       done();
     });
 
+    it('should define default \'largeOperations\'', function(done) {
+      repo.largeOperations.should.containDeep(['log', 'ls-files']);
+      done();
+    });
+
+    it('should define default \'largeOperationsMaxBuffer\'', function(done) {
+      repo.largeOperationsMaxBuffer.should.equal(1024 * 5000);
+      done();
+    });
+
+    it('should use specified \'gitpath\'', function(done) {
+      var repo2 = new Repository(HOME + '/.gitty/test', '/myPathToGit');
+      repo2.gitpath.should.equal('/myPathToGit');
+      repo2.on('ready', done);
+    });
+
+    it('should use specified \'gitpath\' within gitpathOrOpts object',
+      function(done) {
+
+      var repo2 = new Repository(HOME + '/.gitty/test', {gitpath:'/myPathToGit'});
+      repo2.gitpath.should.equal('/myPathToGit');
+      repo2.largeOperations.should.containDeep(['log', 'ls-files']);
+      repo2.largeOperationsMaxBuffer.should.equal(1024 * 5000);
+      repo2.on('ready', done);
+    });
+
+    it('should use specified \'largeOperations\' within gitpathOrOpts object',
+      function(done) {
+
+      var repo2 = new Repository(HOME + '/.gitty/test', {
+        largeOperations: ['log', 'ls-files', 'status', 'commit']
+      });
+      repo2.gitpath.should.equal('');
+      repo2.largeOperations.should.containDeep(['log', 'ls-files', 'status',
+                                                'commit']);
+      repo2.largeOperationsMaxBuffer.should.equal(1024 * 5000);
+      repo2.on('ready', done);
+    });
+
+    it('should use specified \'largeOperationsMaxBuffer\' within ' +
+       'gitpathOrOpts object', function(done) {
+      var repo2 = new Repository(HOME + '/.gitty/test', {
+        largeOperationsMaxBuffer: 1024 * 10000
+      });
+      repo2.gitpath.should.equal('');
+      repo2.largeOperations.should.containDeep(['log', 'ls-files']);
+      repo2.largeOperationsMaxBuffer.should.equal(1024 * 10000);
+      repo2.on('ready', done);
+    });
+
+    it('should use specified \'gitpath\', \'largeOperations\', and ' +
+       '\'largeOperationsMaxBuffer\'', function(done) {
+      var repo2 = new Repository(HOME + '/.gitty/test', {
+        gitpath: '/myPathToGit',
+        largeOperations: ['log', 'ls-files', 'status', 'commit'],
+        largeOperationsMaxBuffer: 1024 * 10000
+      });
+      repo2.gitpath.should.equal('/myPathToGit');
+      repo2.largeOperations.should.containDeep(['log', 'ls-files', 'status',
+                                                'commit']);
+      repo2.largeOperationsMaxBuffer.should.equal(1024 * 10000);
+      repo2.on('ready', done);
+    });
+
   });
 
 });


### PR DESCRIPTION

I am using gitty with very large repos and have found a need to increase the 'largeOperationsMaxBuffer' and expand the 'largeOperations' (e.g., with status and commit). Since it appears other gitty users do not need this, I've made changes to allow this configuration to be provided by the client. (I realize that using child_process 'spawn' circumvents this issue, but don't believe that significant a change is warranted.) I am happy to discuss or make changes if you prefer a different approach. (note: I will have limited availability for the next two weeks so my responses may be delayed during that timeframe.) If you believe simply adding other git operations as 'largeOperations' and increasing the 'largeOperationsMaxBuffer' without exposing opts to the client is preferable, I could re-submit with those fewer changes. I took the approach in this PR as it appears other gitty users do not need the buffer increased.

On a separate topic, I can also provide a separate PR (as documentation only) that illustrates how to promisify gitty, handle/retry concurrent operations (e.g., when many concurrent requests are being made to 'add' files to a single repo), and how to use with async-await if that is of interest.

Regardless, thanks for consideration of this PR, and thanks for gitty.
(Note: I inadvertently included an es6 syntax within my initial PR. I closed that so I could squash the commit to remove that syntax. Apologies for the misstep.) 
